### PR TITLE
Fix navbar

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,7 @@
     left: 0;
     right: 0;
     background-color: #fffbf7;
+    z-index: 10;
 }
 .navbar > a {
     display: inline;


### PR DESCRIPTION
Con este cambio al nav es más sencillo solucionar este fix, también se soluciona cambiando de `position: relative;` a `position: inherit;` algunas clases que contienen los contenedores de imágenes o las mismas imágenes.